### PR TITLE
Add missing "PD: Pre-Duty" option

### DIFF
--- a/lib/domain/models/unit/unit_status.dart
+++ b/lib/domain/models/unit/unit_status.dart
@@ -13,7 +13,8 @@ enum UnitStatus {
   ah('AH', 'At Hospital'),
   ho('HO', 'Handover'),
   vc('VC', 'Vehicle Clear'),
-  os('OS', 'Out of Service');
+  os('OS', 'Out of Service'),
+  pd('PD', 'Pre-Duty');
 
   const UnitStatus(this.abbreviation, this.name);
 


### PR DESCRIPTION
Adds Pre-Duty option for `UnitStatus` that was originally missing in #12 .